### PR TITLE
Feature/add history current

### DIFF
--- a/dwm/dwm.py
+++ b/dwm/dwm.py
@@ -140,6 +140,14 @@ def dwmOne(data, db, config, writeContactHistory=True, returnHistoryId=True, his
         history['timestamp'] = int(time.time())
         history[histIdField['name']] = data[histIdField['value']]
         history['configName'] = config['configName']
+
+        # Set _current value for most recent contact
+        history['_current'] = 0
+       
+        # Increment all _current
+        db['contactHistory'].update({histIdField['name']: data[histIdField['value']]}, {'$inc': {'_current': 1}}, multi=True)
+
+        # Insert into DB
         historyId = db['contactHistory'].insert_one(history).inserted_id
 
     if writeContactHistory and returnHistoryId:

--- a/dwm/test/test_dwm.py
+++ b/dwm/test/test_dwm.py
@@ -417,10 +417,10 @@ def test_writeContactHistory_currentFieldInc():
     # Drop contactHistory before new UT
     db.contactHistory.drop()
     # Create ContactHistory with _currentField
-    dataOutOldRec = dwmAll(data=test_records.record_writeContactHistory_writeConfig, db=db, configName='test_writeContactHistory_writeConfig')
+    dataOutOldRec = dwmAll(data=test_records.record_writeContactHistory_historyCurrent1, db=db, configName='test_writeContactHistory_writeConfig')
 
     # Create new ContactHistory with _currentField and increment old record.
-    dataOutNextRec = dwmAll(data=test_records.history_normIncludes_included_caught, db=db, configName='test_writeContactHistory_writeConfig')
+    dataOutNextRec = dwmAll(data=test_records.record_writeContactHistory_historyCurrent2, db=db, configName='test_writeContactHistory_writeConfig')
 
     # Get old rec with incremented _current
     hist = db.contactHistory.find_one({"_id": dataOutOldRec[0]['historyId']})

--- a/dwm/test/test_dwm.py
+++ b/dwm/test/test_dwm.py
@@ -405,8 +405,28 @@ def test_history_fieldSpecificLookup_notChecked():
     hist = db.contactHistory.find_one({"_id": dataOut[0]['historyId']})
     assert 'field2' not in hist.keys()
 
-# normLookup
 
+# # CurrentFieldLookup
+def test_writeContactHistory_currentField():
+
+    dataOut = dwmAll(data = test_records.record_writeContactHistory_writeConfig, db = db, configName='test_writeContactHistory_writeConfig')
+    hist = db.contactHistory.find_one({"_id": dataOut[0]['historyId']})
+    assert hist['_current'] == 0
+
+def test_writeContactHistory_currentFieldInc():
+    # Drop contactHistory before new UT
+    db.contactHistory.drop()
+    # Create ContactHistory with _currentField
+    dataOutOldRec = dwmAll(data=test_records.record_writeContactHistory_writeConfig, db=db, configName='test_writeContactHistory_writeConfig')
+
+    # Create new ContactHistory with _currentField and increment old record.
+    dataOutNextRec = dwmAll(data=test_records.history_normIncludes_included_caught, db=db, configName='test_writeContactHistory_writeConfig')
+
+    # Get old rec with incremented _current
+    hist = db.contactHistory.find_one({"_id": dataOutOldRec[0]['historyId']})
+    assert hist['_current'] == 1
+
+# normLookup
 def test_history_normLookup_caught():
 
     # do stuff for testing

--- a/dwm/test/test_records.py
+++ b/dwm/test/test_records.py
@@ -191,6 +191,10 @@ record_writeContactHistory_False = [{"emailAddress": "test@test.com"}]
 
 record_writeContactHistory_writeConfig = [{"emailAddress": "test@test.com"}]
 
+record_writeContactHistory_historyCurrent1 = [{"emailAddress": "test@test.com"}]
+
+record_writeContactHistory_historyCurrent2 = [{"emailAddress": "test@test.com"}]
+
 record_configDoesNotExist = [{"emailAddress": "test@test.com"}]
 
 record_udf_beforeGenericValidation = [{"emailAddress": "test@test.com", "field1": ""}]


### PR DESCRIPTION
Incorporate new implementation:
As a dwm administrator, user can query the records output to contactHistory by a new field called '_current', ('_current' == 0  --> old record; '_current' == 1 --> most recent record), 
So that user can identify non-recent records to remove and recover disk space.