### PR TITLE
dwm - s : change hardcoded dict config values for derive to a list.

### DIFF
--- a/dwm/test/test_configs.py
+++ b/dwm/test/test_configs.py
@@ -191,8 +191,7 @@ configs = [
                     "1": {
                         "type": "deriveValue",
                         "fieldSet": ["field2"],
-                        "overwrite": True,
-                        "blankIfNoMatch": False
+                        "options": ["overwrite"]
                     }
                 }
             }
@@ -224,8 +223,7 @@ configs = [
                     "1": {
                         "type": "deriveValue",
                         "fieldSet": ["field2"],
-                        "overwrite": True,
-                        "blankIfNoMatch": True
+                        "options": ["overwrite", "blankIfNoMatch"]
                     }
                 }
             }
@@ -257,14 +255,12 @@ configs = [
                     "2": {
                         "type": "deriveValue",
                         "fieldSet": ["field4"],
-                        "overwrite": True,
-                        "blankIfNoMatch": False
+                        "options": ["overwrite"]
                     },
                     "1": {
                         "type": "deriveValue",
                         "fieldSet": ["field3"],
-                        "overwrite": True,
-                        "blankIfNoMatch": False
+                        "options": ["overwrite"]
                     }
                 }
             }
@@ -296,7 +292,7 @@ configs = [
                     "1": {
                         "type": "copyValue",
                         "fieldSet": ["field2"],
-                        "overwrite": True
+                        "options": ["overwrite"]
                     }
                 }
             }
@@ -328,8 +324,7 @@ configs = [
                     "1": {
                         "type": "deriveRegex",
                         "fieldSet": ["field2"],
-                        "overwrite": True,
-                        "blankIfNoMatch": False
+                        "options": ["overwrite"]
                     }
                 }
             }
@@ -361,8 +356,7 @@ configs = [
                     "1": {
                         "type": "deriveIncludes",
                         "fieldSet": ["field2"],
-                        "overwrite": True,
-                        "blankIfNoMatch": False
+                        "options": ["overwrite"]
                     }
                 }
             }
@@ -394,8 +388,7 @@ configs = [
                     "1": {
                         "type": "deriveIncludes",
                         "fieldSet": ["field2"],
-                        "overwrite": False,
-                        "blankIfNoMatch": False
+                        "options": []
                     }
                 }
             }
@@ -427,8 +420,7 @@ configs = [
                     "1": {
                         "type": "deriveIncludes",
                         "fieldSet": ["field2"],
-                        "overwrite": True,
-                        "blankIfNoMatch": True
+                        "options": ["overwrite", "blankIfNoMatch"]
                     }
                 }
             }
@@ -460,8 +452,7 @@ configs = [
                     "1": {
                         "type": "deriveRegex",
                         "fieldSet": ["field2"],
-                        "overwrite": True,
-                        "blankIfNoMatch": True
+                        "options": ["overwrite", "blankIfNoMatch"]
                     }
                 }
             }
@@ -493,8 +484,7 @@ configs = [
                     "1": {
                         "type": "deriveValue",
                         "fieldSet": ["field2"],
-                        "overwrite": False,
-                        "blankIfNoMatch": False
+                        "options": []
                     }
                 }
             }
@@ -526,8 +516,7 @@ configs = [
                     "1": {
                         "type": "deriveRegex",
                         "fieldSet": ["field2"],
-                        "overwrite": False,
-                        "blankIfNoMatch": False
+                        "options": []
                     }
                 }
             }

--- a/dwm/wrappers.py
+++ b/dwm/wrappers.py
@@ -47,6 +47,16 @@ def DeriveDataLookupAll(data, configFields, db, histObj={}):
     :param dict histObj: History object to which changes should be appended
     """
 
+    def checkDeriveOptions(option, derive_set_config):
+        """
+        Check derive option is exist into options list and return relevant flag.
+        :param option: drive options value
+        :param derive_set_config: options list
+        :return: boolean True or False based on option exist into options list
+        """
+
+        return option in derive_set_config
+
     for field in configFields.keys():
 
         if field in data.keys():
@@ -69,19 +79,19 @@ def DeriveDataLookupAll(data, configFields, db, histObj={}):
 
                     if deriveSetConfig['type']=='deriveValue':
 
-                        fieldValNew, histObj = DeriveDataLookup(fieldName=field, db=db, deriveInput=deriveInput, overwrite=deriveSetConfig['overwrite'], fieldVal=fieldVal, histObj=histObj, blankIfNoMatch=deriveSetConfig['blankIfNoMatch'])
+                        fieldValNew, histObj = DeriveDataLookup(fieldName=field, db=db, deriveInput=deriveInput, overwrite=checkDeriveOptions('overwrite', deriveSetConfig["options"]), fieldVal=fieldVal, histObj=histObj, blankIfNoMatch=checkDeriveOptions('blankIfNoMatch', deriveSetConfig["options"]))
 
                     elif deriveSetConfig['type']=='copyValue':
 
-                        fieldValNew, histObj = DeriveDataCopyValue(fieldName=field, deriveInput=deriveInput, overwrite=deriveSetConfig['overwrite'], fieldVal=fieldVal, histObj=histObj)
+                        fieldValNew, histObj = DeriveDataCopyValue(fieldName=field, deriveInput=deriveInput, overwrite=checkDeriveOptions('overwrite', deriveSetConfig["options"]), fieldVal=fieldVal, histObj=histObj)
 
                     elif deriveSetConfig['type']=='deriveRegex':
 
-                        fieldValNew, histObj = DeriveDataRegex(fieldName=field, db=db, deriveInput=deriveInput, overwrite=deriveSetConfig['overwrite'], fieldVal=fieldVal, histObj=histObj, blankIfNoMatch=deriveSetConfig['blankIfNoMatch'])
+                        fieldValNew, histObj = DeriveDataRegex(fieldName=field, db=db, deriveInput=deriveInput, overwrite=checkDeriveOptions('overwrite', deriveSetConfig["options"]), fieldVal=fieldVal, histObj=histObj, blankIfNoMatch=checkDeriveOptions('blankIfNoMatch', deriveSetConfig["options"]))
 
                     elif deriveSetConfig['type']=='deriveIncludes':
 
-                        fieldValNew, histObj = IncludesLookup(fieldVal=data[field], lookupType='deriveIncludes', deriveFieldName=deriveSetConfig['fieldSet'][0], deriveInput=deriveInput,  db=db, fieldName=field, histObj=histObj, overwrite=deriveSetConfig['overwrite'], blankIfNoMatch=deriveSetConfig['blankIfNoMatch'])
+                        fieldValNew, histObj = IncludesLookup(fieldVal=data[field], lookupType='deriveIncludes', deriveFieldName=deriveSetConfig['fieldSet'][0], deriveInput=deriveInput,  db=db, fieldName=field, histObj=histObj, overwrite=checkDeriveOptions('overwrite', deriveSetConfig["options"]), blankIfNoMatch=checkDeriveOptions('blankIfNoMatch', deriveSetConfig["options"]))
 
                 if fieldValNew!=fieldVal:
 


### PR DESCRIPTION
Feature request: 

Currently, in the "derive" settings each option is passed as a hardcoded dict value: 
```
{
  "type": ...,
  "fieldSet": ...,
  "overwrite": True,
  "blankIfNoMatch": False
}
```

Would like to make this more scalable to add more options in future feature requests. We can do this by removing the hardcoded options and changing to a general "options" value, which is a passed list:

```
{
  "type": ...,
  "fieldSet": ...,
  "options": ["overwrite", "blankIfNoMatch"]
}
```

where each option value, if included in the list, is counted as True. 

Definition of done: 
 - passing nosetests
 - passing tox test for python 2.7, 3.3, 3.4, and 3.5